### PR TITLE
Started the tag functionality for community centers 

### DIFF
--- a/backend/prisma/migrations/20250701223402_updated_tag_table/migration.sql
+++ b/backend/prisma/migrations/20250701223402_updated_tag_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Tag` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -98,7 +98,7 @@ model CenterHours {
 
 model Tag {
  id          Int      @id @default(autoincrement())
- name        String // tag label
+ name        String   @unique // tag label - made unique to prevent duplicates
 
  centerTags  CenterTag[] // relatinoship to junction table
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -2,6 +2,32 @@ const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
 async function main() {
+  // create predefined tags that users can choose from when writing reviews
+  const tags = [
+    { name: "Family Friendly" },
+    { name: "Fast WiFi" },
+    { name: "Open Late" },
+    { name: "Early Hours" },
+    { name: "Near Transportation" },
+    { name: "24/7" },
+    { name: "Quiet" },
+    { name: "Safe" },
+    { name: "Clean" },
+    { name: " Wheelchair Accessible" },
+    { name: "Printer Access" },
+    { name: "Open Weekends" },
+    { name: "Busy" }
+  ];
+
+  // create each tag using upsert to avoid duplicates
+  for (const tagData of tags) {
+    await prisma.tag.upsert({
+      where: { name: tagData.name },
+      update: {}, // don't update anything if it exists
+      create: tagData, // create if it doesn't exist
+    });
+  }
+
   // Create 5 Community Centers with simple data
   const centers = [
     {

--- a/frontend/src/MapView.jsx
+++ b/frontend/src/MapView.jsx
@@ -1,9 +1,19 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import "./MapView.css";
 
 const MapView = () => {
+  const navigate = useNavigate();
+
+  const handleBackClick = () => {
+    navigate("/community-centers");
+  };
+
   return (
     <div className="mapview-container">
+      <div className="back-container">
+        <button className="back-button" onClick={handleBackClick}>Back</button>
+      </div>
       <div className="mapview-content">
         <h1 className="mapview-title">Map View</h1>
         <p className="mapview-description">

--- a/frontend/src/Reviews.jsx
+++ b/frontend/src/Reviews.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 // Import useParams hook to read URL parameters so we can extract centerId from url path
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 // import api functions to fetch reviews and community center info from backend
 import { reviewAPI, communityAPI, userAPI } from "./api"; // added import userAPI to fetch current user data from db
 import {
@@ -18,6 +18,7 @@ const Reviews = () => {
   // When URL is /reviews/5, this will give us { centerId: "5" }
   // Note: URL params are always strings, so we'll need to convert to number when making API calls
   const { centerId } = useParams();
+  const navigate = useNavigate();
 
   // get current user from auth context
   const { isAuthenticated } = useAuth();
@@ -128,6 +129,11 @@ const Reviews = () => {
     setEditingReview(null);
   };
 
+  // function to handle back button click
+  const handleBackClick = () => {
+    navigate("/community-centers");
+  };
+
   if (loading) {
     return (
       <div className="reviews-container">
@@ -153,6 +159,13 @@ const Reviews = () => {
   return (
     <div className="reviews-container">
       <div className="reviews-content">
+        {/* back button */}
+        <div className="back-container">
+          <button className="back-button" onClick={handleBackClick}>
+            Back to Community Centers
+          </button>
+        </div>
+
         {/* community center header Section */}
         {center && (
           <div className="center-header">

--- a/frontend/src/SpecificMap.jsx
+++ b/frontend/src/SpecificMap.jsx
@@ -1,9 +1,21 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import "./SpecificMap.css";
 
 const SpecificMap = () => {
+  const navigate = useNavigate();
+
+  const handleBackClick = () => {
+    navigate("/community-centers");
+  };
+
   return (
     <div className="map-container">
+      <div className="back-container">
+        <button className="back-button" onClick={handleBackClick}>
+          Back to Community Centers
+        </button>
+      </div>
       <div className="map-content">
         <h1 className="map-title">Specific Map</h1>
         <p className="map-description">

--- a/frontend/src/TagSelector.css
+++ b/frontend/src/TagSelector.css
@@ -1,0 +1,128 @@
+.tag-selector {
+  margin-bottom: 1.5rem;
+}
+
+.tag-selector-label {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 10px;
+  display: block;
+}
+
+.tag-selector-info {
+  margin-bottom: 15px;
+}
+
+.selected-count {
+  font-size: 0.9rem;
+  color: #486284;
+  font-weight: 500;
+  margin-bottom: 5px;
+}
+
+.max-reached {
+  font-size: 0.85rem;
+  color: #dc3545;
+  font-style: italic;
+  background-color: #f8d7da;
+  padding: 8px 12px;
+  border-radius: 4px;
+  border: 1px solid #f5c6cb;
+}
+
+.tags-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.tag-chip {
+  padding: 8px 16px;
+  border: 1px solid #e1e5e9;
+  border-radius: 6px;
+  background-color: #fff;
+  color: #333;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.tag-chip:hover:not(:disabled) {
+  border-color: #486284;
+  background-color: #f8f9fa;
+}
+
+.tag-chip.selected {
+  background-color: #486284;
+  color: white;
+  border-color: #486284;
+}
+
+.tag-chip.selected:hover {
+  background-color: #3a4f6b;
+  border-color: #3a4f6b;
+}
+
+.tag-chip.disabled {
+  background-color: #f8f9fa;
+  color: #6c757d;
+  border-color: #dee2e6;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.tag-chip.disabled:hover {
+  border-color: #dee2e6;
+  background-color: #f8f9fa;
+}
+
+.tag-loading {
+  color: #6c757d;
+  font-style: italic;
+  padding: 20px 0;
+  text-align: center;
+}
+
+.tag-error {
+  color: #dc3545;
+  background-color: #f8d7da;
+  padding: 12px 16px;
+  border-radius: 6px;
+  border: 1px solid #f5c6cb;
+  font-size: 0.9rem;
+}
+
+.no-tags {
+  color: #6c757d;
+  font-style: italic;
+  padding: 20px 0;
+  text-align: center;
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+  .tags-container {
+    gap: 8px;
+  }
+
+  .tag-chip {
+    padding: 6px 12px;
+    font-size: 0.85rem;
+  }
+
+  .max-reached {
+    font-size: 0.8rem;
+    padding: 6px 10px;
+  }
+}
+
+/* focus styles for accessibility */
+.tag-chip:focus {
+  outline: none;
+  border-color: #486284;
+}

--- a/frontend/src/TagSelector.jsx
+++ b/frontend/src/TagSelector.jsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from "react";
+import "./TagSelector.css";
+import { tagAPI } from "./api";
+
+// destructuring props to make it easier to use with default values
+const TagSelector = ({ selectedTags = [], onTagsChange, maxTags = 5 }) => {
+  // state for available tags from the api
+  const [availableTags, setAvailableTags] = useState([]);
+  // state for loading and error handling
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // fetch available tags when component mounts
+  useEffect(() => {
+    const fetchTags = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const tags = await tagAPI.getAllTags();
+        setAvailableTags(tags);
+      } catch (err) {
+        console.error("Error fetching tags:", err);
+        setError("Failed to load tags. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTags();
+  }, []);
+
+  // handle tag selection/deselection
+  const handleTagClick = (tagId) => {
+    let newSelectedTags;
+
+    if (selectedTags.includes(tagId)) {
+      // tag is already selected, remove it
+      newSelectedTags = selectedTags.filter(id => id !== tagId);
+    } else {
+      // tag is not selected, add it if under max limit
+      if (selectedTags.length >= maxTags) {
+        return; // don't add if at max limit
+      }
+      // spread operator to add new tag to existing array
+      newSelectedTags = [...selectedTags, tagId];
+    }
+
+    // call parent component's callback with new selection
+    onTagsChange(newSelectedTags);
+  };
+
+  // helper to check if a tag is selected
+  const isTagSelected = (tagId) => {
+    return selectedTags.includes(tagId);
+  };
+
+  // helper to check if we can select more tags
+  const canSelectMore = selectedTags.length < maxTags;
+
+  // early return pattern for loading state - shows loading message while API call is in progress
+  // this prevents the main component from rendering until data is ready
+  if (isLoading) {
+    return (
+      <div className="tag-selector">
+        <div className="tag-selector-label">Tags (optional)</div>
+        <div className="tag-loading">Loading tags...</div>
+      </div>
+    );
+  }
+
+  // early return pattern for error state - shows error message if API call failed
+  // this prevents the main component from rendering and shows user-friendly error
+  if (error) {
+    return (
+      <div className="tag-selector">
+        <div className="tag-selector-label">Tags (optional)</div>
+        <div className="tag-error">{error}</div>
+      </div>
+    );
+  }
+
+  // main component render
+  return (
+    <div className="tag-selector">
+      {/* component title with dynamic max tags display */}
+      <div className="tag-selector-label">
+        Tags (optional) - Select up to {maxTags}
+      </div>
+
+      {/* info section - shows selection status and warnings */}
+      <div className="tag-selector-info">
+        {/*only show count if user has selected tags */}
+        {selectedTags.length > 0 && (
+          <div className="selected-count">
+            {selectedTags.length} of {maxTags} tags selected
+          </div>
+        )}
+        {/* only show warning when max limit reached */}
+        {selectedTags.length >= maxTags && (
+          <div className="max-reached">
+            Maximum tags reached. Deselect a tag to choose a different one.
+          </div>
+        )}
+      </div>
+
+      {/* displays all available tags  */}
+      <div className="tags-container">
+        {/* map through each tag object and create a button for each one */}
+        {availableTags.map((tag) => {
+          // calculate button states for this specific tag
+          const isSelected = isTagSelected(tag.id);
+          const isDisabled = !isSelected && !canSelectMore;
+
+          return (
+            <button
+              key={tag.id}
+              type="button"
+              className={`tag-chip ${isSelected ? 'selected' : ''} ${isDisabled ? 'disabled' : ''}`}
+              onClick={() => handleTagClick(tag.id)}
+              disabled={isDisabled}
+              // dynamic tooltip text that explains what will happen when clicked
+              title={isDisabled ? `Maximum ${maxTags} tags allowed` : `Click to ${isSelected ? 'deselect' : 'select'} ${tag.name}`}
+            >
+              {/* display the tag name from the database */}
+              {tag.name}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* fallback message if no tags are available from the api */}
+      {availableTags.length === 0 && (
+        <div className="no-tags">No tags available</div>
+      )}
+    </div>
+  );
+};
+
+export default TagSelector;

--- a/frontend/src/WriteReview.jsx
+++ b/frontend/src/WriteReview.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import "./WriteReview.css";
 import { reviewAPI } from "./api";
+import TagSelector from "./TagSelector";
 
 const WriteReview = ({ centerId, onCancel, onSuccess }) => {
   // state for star rating intial calue 0
@@ -16,6 +17,8 @@ const WriteReview = ({ centerId, onCancel, onSuccess }) => {
   const [imageUrls, setImageUrls] = useState([]);
   // state for new image URL input
   const [newImageUrl, setNewImageUrl] = useState("");
+  // state for selected tags
+  const [selectedTags, setSelectedTags] = useState([]);
 
   // handle star click
   const handleStarClick = (starValue) => {
@@ -82,6 +85,7 @@ const WriteReview = ({ centerId, onCancel, onSuccess }) => {
         center_id: centerId,
         comment: reviewText.trim(), // send the actual review text instead of empty string
         image_urls: imageUrls.filter((url) => url.trim() !== ""), // include image URLs, filter out empty ones
+        selected_tags: selectedTags, // include selected tag ids
       });
 
       // call success callback to close and refresh reviews
@@ -138,6 +142,13 @@ const WriteReview = ({ centerId, onCancel, onSuccess }) => {
             onChange={handleCommentChange}
           />
         </div>
+
+        {/* tag selection section - optional tags */}
+        <TagSelector
+          selectedTags={selectedTags}
+          onTagsChange={setSelectedTags}
+          maxTags={3}
+        />
 
         {/* images section - optional image uploads */}
         <div className="images-section">

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -156,5 +156,27 @@ export const reviewAPI = {
   },
 };
 
+// api functions for tag operations
+export const tagAPI = {
+  // get all available tags
+  getAllTags: () => apiRequest("/tags"),
+
+  // get tags for a specific community center
+  getCenterTags: (centerId) => apiRequest(`/tags/center/${parseInt(centerId)}`),
+
+  // add a tag to a community center
+  addTagToCenter: (centerId, tagId) =>
+    apiRequest(`/tags/center/${parseInt(centerId)}`, {
+      method: "POST",
+      body: JSON.stringify({ tag_id: tagId }),
+    }),
+
+  // remove a tag from a community center
+  removeTagFromCenter: (centerId, tagId) =>
+    apiRequest(`/tags/center/${parseInt(centerId)}/tag/${parseInt(tagId)}`, {
+      method: "DELETE",
+    }),
+};
+
 // export the base apiRequest function for custom requests
 export { apiRequest };


### PR DESCRIPTION
This PR adds functionality that allows users to select up to three tags (that describe the community center) when writing a review for a community center. The selected tags are stored in the database and linked to the corresponding center. On the frontend, a new tag selector component was created and integrated into the review form. On the backend, the review endpoints were updated to handle tag selection, with validation in place to enforce the tag limit and prevent duplicates. The database schema was also updated to include a unique constraint on tag names, and the seed file now uses upserts for creating tags preventing dups.

Next steps are to include making the selected tags visible to other users, allowing users to edit their tags when editing reviews, and showing the most commonly used tags for each center, either on the center’s detail page or in the community center list.

https://pxl.cl/7CGf4