### PR TITLE
Finished tag functionality 

### DIFF
--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -1,0 +1,6 @@
+// global constants for the application
+const MAX_TAGS_PER_REVIEW = 3;
+
+module.exports = {
+  MAX_TAGS_PER_REVIEW,
+};

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -1,6 +1,0 @@
-// global constants for the application
-const MAX_TAGS_PER_REVIEW = 3;
-
-module.exports = {
-  MAX_TAGS_PER_REVIEW,
-};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,19 +9,19 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^6.10.1",
+        "@prisma/client": "^6.11.0",
         "@supabase/supabase-js": "^2.50.2",
         "cors": "^2.8.5",
         "express": "^5.1.0"
       },
       "devDependencies": {
-        "prisma": "^6.10.1"
+        "prisma": "^6.11.0"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.1.tgz",
-      "integrity": "sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.11.0.tgz",
+      "integrity": "sha512-K9TkKepOYvCOg3qCuKz7ZHf6rf58BFKi08plKjU4qVv9y7/UxO6tLz7PlWcgODUZKURLPmRHjHERffIx/8az4w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
-      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.11.0.tgz",
+      "integrity": "sha512-icBfutMpdrwSf2ggo012zhQ4oianijXL/UPbv4PNVK3WUWbB3/F5Ltq8ZfElGrtwKC6XuFFPxU5qDC9x7vh8zQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -51,53 +51,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
-      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.11.0.tgz",
+      "integrity": "sha512-zo4oEZMWMt0BFWl+4NK9FUpaEOmjGR3y2/r0lkW/DK4BUBRgMj90s8QqK2K+vXG3xn0nAGg2kOSu+Swn60CFLg==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
-      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.11.0.tgz",
+      "integrity": "sha512-uqnYxvPKZPvYZA7F0q4gTR+fVWUJSY5bif7JAKBIOD5SoRRy0qEIaPy4Nna5WDLQaFGshaY/Bh8dLOQMfxhJJw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1",
-        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-        "@prisma/fetch-engine": "6.10.1",
-        "@prisma/get-platform": "6.10.1"
+        "@prisma/debug": "6.11.0",
+        "@prisma/engines-version": "6.11.0-18.9c30299f5a0ea26a96790e13f796dc6094db3173",
+        "@prisma/fetch-engine": "6.11.0",
+        "@prisma/get-platform": "6.11.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
-      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
+      "version": "6.11.0-18.9c30299f5a0ea26a96790e13f796dc6094db3173",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.11.0-18.9c30299f5a0ea26a96790e13f796dc6094db3173.tgz",
+      "integrity": "sha512-M3vbyDICFIA1oJl0cFkM0omD4HsJZjFi0hu0f0UxyPABH8KEcZyUd5BToCrNl4B8lUeQn+L5+gfaQleOKp6Lrg==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
-      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.11.0.tgz",
+      "integrity": "sha512-ZHHSP7vJFo5hePH+MNovxhqXabIg38ZpCwQfUBON29kwPX3f1pjYnzGpgJLCJy4k7mKGOzTgrXPqH8+nJvq2fw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1",
-        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-        "@prisma/get-platform": "6.10.1"
+        "@prisma/debug": "6.11.0",
+        "@prisma/engines-version": "6.11.0-18.9c30299f5a0ea26a96790e13f796dc6094db3173",
+        "@prisma/get-platform": "6.11.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
-      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.11.0.tgz",
+      "integrity": "sha512-yspBGvOfJQwuoApk5B4aBlHDy6YDXAOe4Ml8U2eZ+M2b7fDd10YDomS3Q4qrYHUUVYF3TJyN86NcnRMOvCMUrA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1"
+        "@prisma/debug": "6.11.0"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -791,15 +791,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
-      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.11.0.tgz",
+      "integrity": "sha512-gI69E7fusgk32XALpXzdgR10xUx2aFnHiu/JaUo4O07G4JvFT0xNtD0Iy81p37iBLTYFEhWa9VrHKXaiyZ5fLQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.10.1",
-        "@prisma/engines": "6.10.1"
+        "@prisma/config": "6.11.0",
+        "@prisma/engines": "6.11.0"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,12 +12,12 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@prisma/client": "^6.10.1",
+    "@prisma/client": "^6.11.0",
     "@supabase/supabase-js": "^2.50.2",
     "cors": "^2.8.5",
     "express": "^5.1.0"
   },
   "devDependencies": {
-    "prisma": "^6.10.1"
+    "prisma": "^6.11.0"
   }
 }

--- a/backend/prisma/migrations/20250703212158_on_del_cascade_review_tag/migration.sql
+++ b/backend/prisma/migrations/20250703212158_on_del_cascade_review_tag/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "ReviewTag" DROP CONSTRAINT "ReviewTag_review_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "ReviewTag" ADD CONSTRAINT "ReviewTag_review_id_fkey" FOREIGN KEY ("review_id") REFERENCES "Review"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -123,7 +123,7 @@ model ReviewTag {
  review_id   Int
  tag_id      Int
 
- review      Review @relation(fields: [review_id], references: [id])
+ review      Review @relation(fields: [review_id], references: [id], onDelete: Cascade)
  tag         Tag    @relation(fields: [tag_id], references: [id])
 
  @@unique([review_id, tag_id]) // to prevent duplicate tag assignments for same review

--- a/backend/routes/reviews.js
+++ b/backend/routes/reviews.js
@@ -313,7 +313,7 @@ router.put("/:id", authenticateUser, async (req, res) => {
       }
     }
 
-    // Fetch the updated review with images and user info
+    // Fetch the updated review with images, user info, and tags
     const reviewWithImages = await prisma.review.findUnique({
       where: { id: parseInt(id) },
       include: {
@@ -324,6 +324,12 @@ router.put("/:id", authenticateUser, async (req, res) => {
             first_name: true,
             last_name: true,
             username: true,
+          },
+        },
+        // include reviewTags relationship so frontend gets updated tags
+        reviewTags: {
+          include: {
+            tag: true,
           },
         },
       },

--- a/backend/routes/reviews.js
+++ b/backend/routes/reviews.js
@@ -357,10 +357,6 @@ router.delete("/:id", authenticateUser, async (req, res) => {
       where: { review_id: parseInt(id) },
     });
 
-    // delete all associated review tags
-    await prisma.reviewTag.deleteMany({
-      where: { review_id: parseInt(id) },
-    });
 
     // now delete the review
     await prisma.review.delete({

--- a/backend/routes/reviews.js
+++ b/backend/routes/reviews.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const { PrismaClient } = require("@prisma/client");
 const { authenticateUser } = require("../middleware/auth"); // imports middleware function that verifies jwt tokens to verify user identity before allowing operations
-const { MAX_TAGS_PER_REVIEW } = require("../config/constants");
 const router = express.Router();
 const prisma = new PrismaClient();
 
@@ -97,19 +96,6 @@ router.post("/", authenticateUser, async (req, res) => {
 
     // extract data from request body (no longer accepting user_id since we get it from authentication)
     const { rating, comment, center_id, image_urls, selected_tags } = req.body;
-
-    // validate if selected_tags exists and is an array with maximum allowed tags
-    if (
-      selected_tags &&
-      (!Array.isArray(selected_tags) ||
-        selected_tags.length > MAX_TAGS_PER_REVIEW)
-    ) {
-      return res
-        .status(400)
-        .json({
-          error: `selected_tags must be an array with maximum ${MAX_TAGS_PER_REVIEW} tags`,
-        });
-    }
 
     const newReview = await prisma.review.create({
       data: {
@@ -213,19 +199,6 @@ router.put("/:id", authenticateUser, async (req, res) => {
   try {
     const { id } = req.params;
     const { rating, comment, image_urls, selected_tags } = req.body;
-
-    // validate selected_tags if provided
-    if (
-      selected_tags &&
-      (!Array.isArray(selected_tags) ||
-        selected_tags.length > MAX_TAGS_PER_REVIEW)
-    ) {
-      return res
-        .status(400)
-        .json({
-          error: `selected_tags must be an array with maximum ${MAX_TAGS_PER_REVIEW} tags`,
-        });
-    }
 
     // get db user ID from authenticated user
     const userId = await getUserIdFromSupabase(req.user.id);

--- a/frontend/src/Banner.jsx
+++ b/frontend/src/Banner.jsx
@@ -32,9 +32,10 @@ const Banner = () => {
             connected world.
 
             <br />
-            Whether you're looking to get connected, grow your skills, or give back — WiFind
-            helps you bridge the digital gap. Discover local resources, explore opportunities,
-            and join a community working toward digital equity.
+            Whether you're looking to get connected, grow your skills, or give
+            back — WiFind helps you bridge the digital gap. Discover local
+            resources, explore opportunities, and join a community working
+            toward digital equity.
           </p>
 
           <div className="banner-btns">

--- a/frontend/src/EditReviewForm.jsx
+++ b/frontend/src/EditReviewForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import "./EditReviewForm.css";
+import TagSelector from "./TagSelector";
 
 // this component receives a review object as a prop and allows the user to edit its rating, comment, and images
 const EditReviewForm = ({ review, onSave, onCancel }) => {
@@ -15,6 +16,12 @@ const EditReviewForm = ({ review, onSave, onCancel }) => {
   const [newImageUrl, setNewImageUrl] = useState("");
   // loading state for submit button
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // state to manage which tags are selected
+  // initialize with existing tags from reviewTags relationship
+  const [selectedTags, setSelectedTags] = useState(
+    review.reviewTags ? review.reviewTags.map((reviewTag) => reviewTag.tag.id) : []
+  )
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -38,6 +45,7 @@ const EditReviewForm = ({ review, onSave, onCancel }) => {
         rating: parseInt(rating),
         comment: comment.trim(),
         image_urls: imageUrls.filter((url) => url.trim() !== ""), // remove empty urls
+        selected_tags: selectedTags, // pass selected tags to parent component
       });
       // if successful, parent will handle closing the form and refreshing the data
     } catch (error) {
@@ -102,6 +110,12 @@ const EditReviewForm = ({ review, onSave, onCancel }) => {
             required
           />
         </div>
+        {/* tag selection section - added so users can edit tags when editing review */}
+        <TagSelector
+          selectedTags={selectedTags}
+          onTagsChange={setSelectedTags}
+          maxTags={3}
+          />
 
         {/* images section */}
         <div className="form-group">

--- a/frontend/src/TagSelector.jsx
+++ b/frontend/src/TagSelector.jsx
@@ -1,9 +1,14 @@
 import React, { useState, useEffect } from "react";
 import "./TagSelector.css";
 import { tagAPI } from "./api";
+import { MAX_TAGS_PER_REVIEW } from "./constants";
 
 // destructuring props to make it easier to use with default values
-const TagSelector = ({ selectedTags = [], onTagsChange, maxTags = 3 }) => {
+const TagSelector = ({
+  selectedTags = [],
+  onTagsChange,
+  maxTags = MAX_TAGS_PER_REVIEW,
+}) => {
   // state for available tags from the api
   const [availableTags, setAvailableTags] = useState([]);
   // state for loading and error handling

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,2 @@
+// global constants for the frontend application
+export const MAX_TAGS_PER_REVIEW = 3;


### PR DESCRIPTION
Now users can edit the tags on their reviews. Previously, tags could only be selected during review creation, with no option to modify them afterward. A selectedTags state was added and initialized from the existing review tags, passed to the TagSelector component, and included in the handleSubmit function to ensure selected tag IDs are sent to the backend on save.
Fixed a bug where updated tags would revert to the original ones after saving. This was caused by the backend PUT /reviews/:id route not returning the updated review with its associated tags. The issue was resolved by updating the route’s response to include the review’s tags using Prisma’s include option. With this fix, tag updates persist correctly and are immediately reflected in the UI. Tag functionality is now complete yay!

https://pxl.cl/7D3G6

