### PR TITLE
Added dislike functionality similar to like

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9,6 +9,7 @@ const communityCentersRouter = require("./routes/communityCenters");
 const reviewsRouter = require("./routes/reviews");
 const tagsRouter = require("./routes/tags");
 const likesRouter = require("./routes/likes");
+const dislikesRouter = require("./routes/dislikes");
 
 app.get("/", (req, res) => {
   res.send("Welcome to my app!");
@@ -21,6 +22,7 @@ app.use("/communityCenters", communityCentersRouter);
 app.use("/reviews", reviewsRouter);
 app.use("/tags", tagsRouter);
 app.use("/likes", likesRouter);
+app.use("/dislikes", dislikesRouter);
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);

--- a/backend/prisma/migrations/20250722001820_dislike_model/migration.sql
+++ b/backend/prisma/migrations/20250722001820_dislike_model/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Dislikes" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "center_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Dislikes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Dislikes_user_id_center_id_key" ON "Dislikes"("user_id", "center_id");
+
+-- AddForeignKey
+ALTER TABLE "Dislikes" ADD CONSTRAINT "Dislikes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Dislikes" ADD CONSTRAINT "Dislikes_center_id_fkey" FOREIGN KEY ("center_id") REFERENCES "CommunityCenter"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,6 +34,7 @@ model User {
 
  reviews    Review[]
  likes      Likes[] // relation to liked centers
+ dislikes   Dislikes[] // relation to disliked centers
 }
 
 
@@ -85,6 +86,7 @@ model CommunityCenter {
  hours        CenterHours[]
  centerTags   CenterTag[] // relationship to junction table allows commmunity centet to access their tags
  likedBy      Likes[] // relation to users who liked this center
+ dislikedBy   Dislikes[] // relation to users who disliked this center
 }
 
 
@@ -143,4 +145,17 @@ model Likes {
  center      CommunityCenter @relation(fields: [center_id], references: [id], onDelete: Cascade)
 
  @@unique([user_id, center_id]) // to prevent duplicate likes for the same center by the same user
+}
+
+// model to track which centers users have disliked
+model Dislikes {
+ id          Int      @id @default(autoincrement())
+ user_id     Int
+ center_id   Int
+ created_at  DateTime @default(now())
+
+ user        User            @relation(fields: [user_id], references: [id], onDelete: Cascade)
+ center      CommunityCenter @relation(fields: [center_id], references: [id], onDelete: Cascade)
+
+ @@unique([user_id, center_id]) // to prevent duplicate dislikes for the same center by the same user
 }

--- a/backend/routes/dislikes.js
+++ b/backend/routes/dislikes.js
@@ -1,0 +1,190 @@
+const express = require("express");
+const { PrismaClient } = require("@prisma/client");
+const { authenticateUser } = require("../middleware/auth");
+const { clearCenterCache } = require("../utils/cacheUtils");
+const { getUserIdFromSupabase } = require("../utils/userUtils");
+const { enrichCentersWithData } = require("../utils/centerFilters");
+const router = express.Router();
+const prisma = new PrismaClient();
+
+// (POST) add a dislike
+router.post("/", authenticateUser, async (req, res) => {
+  try {
+    // get user ID from authenticated user
+    const userId = await getUserIdFromSupabase(req.user.id);
+    if (!userId) {
+      return res.status(400).json({ error: "User not found in database" });
+    }
+
+    const { center_id } = req.body;
+    if (!center_id) {
+      return res.status(400).json({ error: "center_id is required" });
+    }
+
+    // check if the community center exists
+    const centerExists = await prisma.communityCenter.findUnique({
+      where: { id: parseInt(center_id) },
+    });
+
+    if (!centerExists) {
+      return res.status(404).json({ error: "Community center not found" });
+    }
+
+    // create the dislike
+    const dislike = await prisma.dislikes.create({
+      data: {
+        user_id: userId,
+        center_id: parseInt(center_id),
+      },
+    });
+
+    // clear cache for this community center
+    clearCenterCache(parseInt(center_id));
+
+    res.status(201).json(dislike);
+  } catch (error) {
+    // handle unique constraint violation (user already disliked this center)
+    if (error.code === "P2002") {
+      return res.status(409).json({
+        error: "You have already disliked this community center",
+      });
+    }
+
+    console.error("Error adding dislike:", error);
+    res.status(500).json({
+      error: "Failed to add dislike",
+      details: error.message,
+    });
+  }
+});
+
+// (DELETE) remove a dislike
+router.delete("/:center_id", authenticateUser, async (req, res) => {
+  try {
+    // get user id from authenticated user
+    const userId = await getUserIdFromSupabase(req.user.id);
+    if (!userId) {
+      return res.status(400).json({ error: "User not found in database" });
+    }
+
+    const { center_id } = req.params;
+
+    // check if the dislike exists
+    const existingDislike = await prisma.dislikes.findFirst({
+      where: {
+        user_id: userId,
+        center_id: parseInt(center_id),
+      },
+    });
+
+    if (!existingDislike) {
+      return res.status(404).json({ error: "Dislike not found" });
+    }
+
+    // remove/delete the dislike
+    await prisma.dislikes.delete({
+      where: {
+        id: existingDislike.id,
+      },
+    });
+
+    // clear cache for this community center
+    clearCenterCache(parseInt(center_id));
+
+    res.status(204).send();
+  } catch (error) {
+    console.error("Error removing dislike:", error);
+    res.status(500).json({
+      error: "Failed to remove dislike",
+      details: error.message,
+    });
+  }
+});
+
+// (GET) endpoint to retrieve a user's dislikes
+router.get("/user", authenticateUser, async (req, res) => {
+  try {
+    // get user id from authenticated user
+    const userId = await getUserIdFromSupabase(req.user.id);
+    if (!userId) {
+      return res.status(400).json({ error: "User not found in database" });
+    }
+
+    // get all dislikes for the user with community center details
+    const dislikes = await prisma.dislikes.findMany({
+      where: {
+        user_id: userId,
+      },
+      include: {
+        center: {
+          include: {
+            hours: true,
+            reviews: {
+              select: {
+                rating: true,
+                created_at: true,
+              },
+            },
+            centerTags: {
+              include: {
+                tag: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        created_at: "desc", // most recent dislikes first
+      },
+    });
+
+    // extract centers from dislikes and enrich them with calculated fields
+    const centers = dislikes.map((dislike) => dislike.center);
+    const enrichedCenters = enrichCentersWithData(centers);
+
+    // reconstruct the dislikes with enriched centers
+    const enrichedDislikes = dislikes.map((dislike, index) => ({
+      ...dislike,
+      center: enrichedCenters[index],
+    }));
+
+    res.json(enrichedDislikes);
+  } catch (error) {
+    console.error("Error fetching user dislikes:", error);
+    res.status(500).json({
+      error: "Failed to fetch dislikes",
+      details: error.message,
+    });
+  }
+});
+
+// (GET) check if a user has disliked a specific center
+router.get("/check/:center_id", authenticateUser, async (req, res) => {
+  try {
+    const userId = await getUserIdFromSupabase(req.user.id);
+    if (!userId) {
+      return res.status(400).json({ error: "User not found in database" });
+    }
+
+    const { center_id } = req.params;
+
+    // check if the dislike exists
+    const dislike = await prisma.dislikes.findFirst({
+      where: {
+        user_id: userId,
+        center_id: parseInt(center_id),
+      },
+    });
+
+    // return true if the dislike exists, false otherwise
+    res.json({ disliked: !!dislike });
+  } catch (error) {
+    console.error("Error checking dislike status:", error);
+    res.status(500).json({
+      error: "Failed to check dislike status",
+      details: error.message,
+    });
+  }
+});
+
+module.exports = router;

--- a/frontend/src/CenterCard.jsx
+++ b/frontend/src/CenterCard.jsx
@@ -1,7 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { likesAPI } from "./api";
-import { useAuth } from "./AuthContext";
 
 // reusable component for displaying a community center card
 // accepts center data and optional props for customization
@@ -13,7 +12,7 @@ const CenterCard = ({
 }) => {
   const navigate = useNavigate();
   const [isLiked, setIsLiked] = useState(false);
-  const { user, isAuthenticated } = useAuth();
+  const [isDisliked, setIsDisliked] = useState(false);
 
   // check if the center is liked when component mounts
   useEffect(() => {
@@ -34,18 +33,20 @@ const CenterCard = ({
     e.stopPropagation();
 
     setIsLiked(!isLiked);
+    // if disliked and user clicks like, remove dislike
+    if (isDisliked) {
+      setIsDisliked(false);
+    }
+  };
 
-    try {
-      // make api call in the background
-      if (!isLiked) {
-        await likesAPI.addLike(center.id);
-      } else {
-        await likesAPI.removeLike(center.id);
-      }
-    } catch (error) {
-      // if api call fails, revert the UI change
-      console.error("Error toggling like:", error);
-      setIsLiked(!isLiked); // revert back if there was an error
+  // handle dislike UI toggle
+  const handleDislikeClick = (e) => {
+    e.stopPropagation();
+
+    setIsDisliked(!isDisliked);
+    // if liked and user clicks dislike, remove like
+    if (isLiked) {
+      setIsLiked(false);
     }
   };
 
@@ -75,14 +76,36 @@ const CenterCard = ({
       <div className="center-info">
         <div className="center-name-container">
           <h3 className="center-name">{center.name}</h3>
-          <span
-          // like button
-            className={`heart-icon ${isLiked ? 'liked' : ''}`}
-            onClick={handleLikeClick}
-            title={isAuthenticated ? (isLiked ? "Unlike" : "Like") : "Login to like"}
-          >
-            ❤︎
-          </span>
+          <div className="reaction-buttons">
+            <span
+              // like button
+              className={`heart-icon ${isLiked ? "liked" : ""}`}
+              onClick={handleLikeClick}
+              title={isLiked ? "Unlike" : "Like"}
+            >
+              ❤︎
+            </span>
+            <span
+              // dislike button
+              className={`thumbs-down-icon ${isDisliked ? "disliked" : ""}`}
+              onClick={handleDislikeClick}
+              title={isDisliked ? "Remove dislike" : "Dislike"}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill={isDisliked ? "currentColor" : "none"}
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M17 14V2M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22h0a3.13 3.13 0 0 1-3-3.88Z" />
+              </svg>
+            </span>
+          </div>
         </div>
         <p className="center-address">{center.address}</p>
         <p className="center-phone">{center.phone_number}</p>
@@ -109,7 +132,6 @@ const CenterCard = ({
               miles
             </p>
           )}
-
 
           {/* rating and review count */}
           <div className="center-rating-container">

--- a/frontend/src/CommunityCenter.css
+++ b/frontend/src/CommunityCenter.css
@@ -60,12 +60,18 @@
   text-align: left;
 }
 
-/* center name container with like button */
+/* center name container with like/dislike buttons */
 .center-name-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin: 0 0 0.75rem 0;
+}
+
+/* container for like/dislike buttons */
+.reaction-buttons {
+  display: flex;
+  gap: 8px;
 }
 
 .center-name {
@@ -83,7 +89,6 @@
   cursor: pointer;
   transition: all 0.2s ease;
   color: #d1d1d1;
-  margin-left: 10px;
   user-select: none;
 }
 
@@ -96,6 +101,28 @@
 }
 
 .heart-icon.loading {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* thumbs down icon styling */
+.thumbs-down-icon {
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: #d1d1d1;
+  user-select: none;
+}
+
+.thumbs-down-icon:hover {
+  transform: scale(1.1);
+}
+
+.thumbs-down-icon.disliked {
+  color: #000000;
+}
+
+.thumbs-down-icon.loading {
   opacity: 0.5;
   pointer-events: none;
 }

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -338,7 +338,7 @@ const Dashboard = () => {
         <LikedCenters />
 
         {/* add the DislikedCenters component for testing */}
-        <DislikedCenters />
+        {/* <DislikedCenters /> */}
       </div>
     </div>
   );

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -3,6 +3,7 @@ import { useAuth } from "./AuthContext";
 import { userAPI } from "./api"; // to make calls to backend
 import { validateEditForm } from "./utils/validation"; // import new validate function from utils
 import LikedCenters from "./LikedCenters";
+import DislikedCenters from "./DislikedCenters"; // Import the DislikedCenters component
 import "./Dashboard.css";
 
 const Dashboard = () => {
@@ -335,6 +336,9 @@ const Dashboard = () => {
 
         {/* add the LikedCenters component */}
         <LikedCenters />
+
+        {/* add the DislikedCenters component for testing */}
+        <DislikedCenters />
       </div>
     </div>
   );

--- a/frontend/src/DislikedCenters.jsx
+++ b/frontend/src/DislikedCenters.jsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from "react";
+import { dislikesAPI } from "./api"; // import API functions for dislikes
+import CenterCard from "./CenterCard"; // reuse the CenterCard component
+import "./LikedCenters.css"; // reuse the same CSS for now
+
+// component to display the user's disliked community centers for testing purposes
+const DislikedCenters = () => {
+  // state to store disliked centers data
+  const [dislikedCenters, setDislikedCenters] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // fetch disliked centers when component mounts
+  useEffect(() => {
+    const fetchDislikedCenters = async () => {
+      try {
+        setLoading(true);
+        // call api to get user's disliked centers
+        const data = await dislikesAPI.getUserDislikes();
+        // extract center data from the api response
+        const centers = data.map((dislike) => dislike.center);
+        setDislikedCenters(centers); // store fetched data in state
+      } catch (err) {
+        console.error("Error fetching disliked centers:", err);
+        setError("Failed to load your disliked centers");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDislikedCenters();
+  }, []); // runs once when component mounts
+
+  return (
+    <div className="liked-centers-container">
+      {/* section title */}
+      <h2 className="liked-centers-title">Your Disliked Centers (Testing)</h2>
+
+      {/* show loading message while fetching data */}
+      {loading && (
+        <div className="liked-centers-loading">
+          <p>Loading your disliked centers...</p>
+        </div>
+      )}
+
+      {/* show error message if an error occurs */}
+      {error && (
+        <div className="liked-centers-error">
+          <p>Error: {error}</p>
+        </div>
+      )}
+
+      {/* show message when user hasn't disliked any centers */}
+      {!loading && !error && dislikedCenters.length === 0 && (
+        <div className="liked-centers-empty">
+          <p>You haven't disliked any community centers yet.</p>
+        </div>
+      )}
+
+      {/* display grid of disliked centers when available */}
+      {!loading && !error && dislikedCenters.length > 0 && (
+        <div className="liked-centers-grid">
+          {/* map through each center and render a CenterCard component */}
+          {dislikedCenters.map((center) => (
+            <CenterCard
+              key={center.id}
+              center={center}
+              showSimilarButton={false} // hide similar centers button in dashboard view
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DislikedCenters;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -100,7 +100,9 @@ export const communityAPI = {
 
   // get recommendations for a specific community center
   getRecommendationsForCenter: (centerId, limit = 5) =>
-    apiRequest(`/communityCenters/${parseInt(centerId)}/recommendations?limit=${limit}`),
+    apiRequest(
+      `/communityCenters/${parseInt(centerId)}/recommendations?limit=${limit}`
+    ),
 
   // function for advanced search filtering to connect frontend to backend api
   // takes in a filters object with distance, hours, rating, and tags properties and coords of user
@@ -328,12 +330,32 @@ export const likesAPI = {
     }),
 
   // get all liked centers for the current user
-  getUserLikes: () =>
-    apiRequest("/likes/user"),
+  getUserLikes: () => apiRequest("/likes/user"),
 
   // check if the current user has liked a specific center
-  checkLikeStatus: (centerId) =>
-    apiRequest(`/likes/check/${centerId}`),
+  checkLikeStatus: (centerId) => apiRequest(`/likes/check/${centerId}`),
+};
+
+// functions for dislike operations
+export const dislikesAPI = {
+  // add a dislike to a community center
+  addDislike: (centerId) =>
+    apiRequest("/dislikes", {
+      method: "POST",
+      body: JSON.stringify({ center_id: centerId }),
+    }),
+
+  // remove a dislike from a community center
+  removeDislike: (centerId) =>
+    apiRequest(`/dislikes/${centerId}`, {
+      method: "DELETE",
+    }),
+
+  // get all disliked centers for the current user
+  getUserDislikes: () => apiRequest("/dislikes/user"),
+
+  // check if the current user has disliked a specific center
+  checkDislikeStatus: (centerId) => apiRequest(`/dislikes/check/${centerId}`),
 };
 
 // export the base apiRequest function for custom requests


### PR DESCRIPTION
## Description

This PR introduces a dislike button to community centers, enabling users to provide negative feedback in addition to likes. The goal is to increase user interaction and gather more nuanced behavior data to support a more accurate, behavior-based recommendation engine. A Dislikes model was added to the Prisma schema with proper relationships and constraints. Backend endpoints support full dislike functionality with mutual exclusivity to likes. On the frontend, a thumbs-down button was added with API integration and state management. A section in the Dashboard displays disliked centers for testing purposes. Not sure, if this will stay but the section proves the dislike functionality is working properly. I would love to hear your thoughts on whether or not this section should stay in the dashboard. 

Next steps:
Now that I have added likes and dislikes, I am ready to start working on the user behavior based recommendation engine. 
 
## Milestones
This is working toward the enhanced TC2 Recommendation system.

## Demo
https://pxl.cl/7Ljvx


