### PR TITLE
Add community center card to the specific center page

### DIFF
--- a/frontend/src/CenterCard.jsx
+++ b/frontend/src/CenterCard.jsx
@@ -266,13 +266,16 @@ const CenterCard = ({
           >
             Reviews
           </button>
-          <button
-            className="map-button"
-            onClick={() => handleMapClick(center.id)}
-            title="View this community center on the map"
-          >
-            Map
-          </button>
+          {/* only show the Map button if hideMapButton is not true */}
+          {!center.hideMapButton && (
+            <button
+              className="map-button"
+              onClick={() => handleMapClick(center.id)}
+              title="View this community center on the map"
+            >
+              Map
+            </button>
+          )}
           {showSimilarButton && (
             <button
               className="similar-centers-button"

--- a/frontend/src/SpecificMap.css
+++ b/frontend/src/SpecificMap.css
@@ -10,8 +10,54 @@
 
 .map-content {
   text-align: center;
-  max-width: 800px;
+  max-width: 1000px;
   width: 100%;
+}
+
+/* to make the CenterCard component wider for the specific map view */
+.map-content .center-card {
+  width: 100%;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.5rem;
+}
+
+/* adjust the center info to be wider */
+.map-content .center-info {
+  width: 100%;
+  padding: 1.5rem;
+}
+
+/* make the center image wider */
+.map-content .center-image {
+  width: 100%;
+  height: 300px;
+  object-fit: cover;
+}
+
+/* adjust layout for larger screens */
+@media (min-width: 768px) {
+  .map-content .center-card {
+    flex-direction: row;
+  }
+
+  .map-content .center-image {
+    width: 40%;
+    height: auto;
+  }
+
+  .map-content .center-info {
+    width: 60%;
+  }
+}
+
+.map-section-title {
+  font-size: 1.5rem;
+  color: #486284;
+  margin: 1.5rem 0 1rem;
+  font-weight: 600;
+  text-align: left;
 }
 
 .back-container {

--- a/frontend/src/SpecificMap.jsx
+++ b/frontend/src/SpecificMap.jsx
@@ -1,7 +1,15 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useLoadScript, GoogleMap, MarkerF } from "@react-google-maps/api"; // import the necessary components from @react-google-maps/api
+import {
+  useLoadScript,
+  GoogleMap,
+  MarkerF,
+  PolylineF, // import polyline for drawing lines between points
+} from "@react-google-maps/api"; // import the necessary components from @react-google-maps/api
 import LoadingSpinner from "./LoadingSpinner";
+import CenterCard from "./CenterCard";
+import SimilarCentersModal from "./SimilarCentersModal";
+import { useGetUserLocation } from "./utils/hooks";
 import "./SpecificMap.css";
 
 // define map container style
@@ -18,6 +26,15 @@ const SpecificMap = () => {
   // state to track loading and error states
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  // state to track if similar centers modal is open
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // use the custom hook to get the user's location
+  const {
+    data: userLocation,
+    isLoading: locationLoading,
+    error: locationError,
+  } = useGetUserLocation();
 
   // 2) load google maps javascript api
   // returns isLoaded (true when maps is ready) and loadError (if loading failed)
@@ -30,39 +47,63 @@ const SpecificMap = () => {
     navigate("/community-centers");
   };
 
+  // function to handle when similar centers is clicked
+  const handleSimilarCentersClick = () => {
+    setModalOpen(true);
+  };
+
+  // function to close similar centers modal
+  const handleCloseModal = () => {
+    setModalOpen(false);
+  };
+
   // fetch the specific community center data from api
   useEffect(() => {
     const fetchCenter = async () => {
       try {
-        // make http request to backend api endpoint, uses centerid from url to get specific center
-        const response = await fetch(
-          `${import.meta.env.VITE_API_BASE_URL}/communityCenters/${centerId}`
-        );
-        if (!response.ok) {
-          throw new Error("Failed to fetch community center");
-        }
-        const data = await response.json();
+        // wait for user location to be available before fetching center data to ensure we have the user's location before calculating distance
+        if (userLocation) {
+          // include user location in the request to calculate distance
+          const response = await fetch(
+            `${
+              import.meta.env.VITE_API_BASE_URL
+            }/communityCenters/${centerId}?userLat=${
+              userLocation.latitude
+            }&userLng=${userLocation.longitude}`
+          );
+
+          if (!response.ok) {
+            throw new Error("Failed to fetch community center");
+          }
+
+          const data = await response.json();
 
         // add artificial delay to see the loading spinner (500ms)
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        // store fetched data in state
-        setCenter(data);
+          // store fetched data in state
+          setCenter(data);
+          setLoading(false);
+        }
       } catch (err) {
         setError(err.message);
-      } finally {
         setLoading(false);
       }
     };
 
     // only fetch if centerId is provided
     if (centerId) {
-      fetchCenter();
+      // if user location is still loading, keep  loading state true
+      if (locationLoading) {
+        setLoading(true);
+      } else {
+        fetchCenter();
+      }
     } else {
       setError("No center ID provided");
       setLoading(false);
     }
-  }, [centerId]); // rerun effect if centerId changes
+  }, [centerId, userLocation, locationLoading]); // rerun effect if centerId or userLocation changes
 
   // loading state
   if (!isLoaded || loading) {
@@ -113,19 +154,54 @@ const SpecificMap = () => {
       </div>
       <div className="map-content">
         <h1 className="map-title">
-          {center ? `${center.name} - Location` : "Community Center"}
+          {center ? `${center.name} - Details` : "Community Center"}
         </h1>
         {/* only show content if loading center data was a success */}
         {center ? (
           <div>
-            <div style={{ marginBottom: "20px" }}>
-              <p>
-                <strong>Address:</strong> {center.address}
-              </p>
-              <p>
-                <strong>Phone:</strong> {center.phone_number}
-              </p>
-            </div>
+            {/* add the centercard component to display all center details */}
+            <CenterCard
+              center={{
+                ...center,
+                // process the data to match what CenterCard expects
+                tags:
+                  center.tags ||
+                  (center.centerTags && Array.isArray(center.centerTags)
+                    ? center.centerTags.map((ct) => ct.tag)
+                    : []),
+                avgRating:
+                  center.avgRating !== undefined ? center.avgRating : null,
+                reviewCount:
+                  center.reviewCount !== undefined ? center.reviewCount : 0,
+                distance:
+                  center.distance !== undefined ? center.distance : null,
+                isOpen: center.isOpen !== undefined ? center.isOpen : null,
+                hoursMessage:
+                  center.hoursMessage || "Hours information unavailable",
+                // add a property to hide the map button
+                hideMapButton: true,
+              }}
+              showSimilarButton={true} // show the similar centers button
+              onSimilarCentersClick={handleSimilarCentersClick} // pass the handler for the similar centers button
+            />
+
+            <h2 className="map-section-title">Location</h2>
+
+            {/* display location status message */}
+            {locationLoading && (
+              <div className="location-status">
+                <p>Getting your location to show on the map...</p>
+              </div>
+            )}
+
+            {locationError && (
+              <div className="location-error">
+                <p>
+                  <strong>Location access issue:</strong> {locationError}
+                </p>
+                <p>Your location will not be shown on the map.</p>
+              </div>
+            )}
 
             {/* add the google map component */}
             <GoogleMap
@@ -144,7 +220,42 @@ const SpecificMap = () => {
                   lat: center.latitude, // same latitude as center from db
                   lng: center.longitude, // same longitude as center
                 }}
+                title={center.name}
               />
+
+              {/* add user location marker if available */}
+              {userLocation && (
+                <>
+                  <MarkerF
+                    position={{
+                      lat: userLocation.latitude,
+                      lng: userLocation.longitude,
+                    }}
+                    title="Your Location"
+                    icon={{
+                      url: "data:image/svg+xml;charset=UTF-8,%3csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='10' cy='10' r='8' fill='%234285f4' stroke='white' stroke-width='2'/%3e%3c/svg%3e",
+                      scaledSize: { width: 20, height: 20 },
+                    }}
+                  />
+
+                  {/* add a line between user location and community center */}
+                  <PolylineF
+                    path={[
+                      {
+                        lat: userLocation.latitude,
+                        lng: userLocation.longitude,
+                      },
+                      { lat: center.latitude, lng: center.longitude },
+                    ]}
+                    options={{
+                      strokeColor: "#4285F4", // google blue color
+                      strokeOpacity: 0.8,
+                      strokeWeight: 3,
+                      geodesic: true, // draw the shortest path on the Earth's surface
+                    }}
+                  />
+                </>
+              )}
             </GoogleMap>
           </div>
         ) : (
@@ -152,6 +263,15 @@ const SpecificMap = () => {
           <p>Community center not found.</p>
         )}
       </div>
+
+      {/* add the SimilarCentersModal component */}
+      {center && (
+        <SimilarCentersModal
+          centerId={center.id}
+          isOpen={modalOpen}
+          onClose={handleCloseModal}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR improves the specific center page by integrating the CenterCard component at the top, displaying full center details (name, address, phone, description, ratings, and tags). It also adds user location support: the map now shows both the user’s current location and the center, connected by a styled polyline. The distance (in miles) is shown in the card, and the page title updates to "[Center Name] - Details" for better context. The "Map" button is removed from this view to avoid redundancy and the distance in miles is added to the card. Styling, responsiveness, and loading/error states for location services have also been improved.

When a user clicks a marker on the map view page (which shows all centers and the user’s location), it now shows a more detailed view—previously it only showed the address and phone number, but now it displays all center info.

Next steps: I’ll keep polishing interactions like marker clicks and begin building out the Resources page.

## Milestones
Polish and stretch features

## Demo
https://pxl.cl/7Np0P



