### PR TITLE
Added edit profile picture functionality to the dashboard

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -4,7 +4,6 @@ const { authenticateUser } = require("../middleware/auth");
 const router = express.Router();
 const prisma = new PrismaClient();
 
-
 // (GET) fetch current user's info by their supabase ID - protected
 // instead of requiring prisma db id, use /me route ro get current user's data
 router.get("/me", authenticateUser, async (req, res) => {
@@ -17,6 +16,14 @@ router.get("/me", authenticateUser, async (req, res) => {
 
     if (!user) {
       return res.status(404).json({ error: "User not found" });
+    }
+
+    // import the DEFAULT_PROFILE_PIC constant
+    const { DEFAULT_PROFILE_PIC } = require("../utils/constants");
+
+    // check if user has a profile picture, if not, assign the default one
+    if (!user.profile_pic) {
+      user.profile_pic = DEFAULT_PROFILE_PIC;
     }
 
     res.json(user); //. return complete user object w all prof data
@@ -45,6 +52,14 @@ router.get("/:userId", authenticateUser, async (req, res) => {
       return res
         .status(403)
         .json({ error: "You can only view your own profile" });
+    }
+
+    // Import the DEFAULT_PROFILE_PIC constant
+    const { DEFAULT_PROFILE_PIC } = require("../utils/constants");
+
+    // Check if user has a profile picture, if not, assign the default one
+    if (!user.profile_pic) {
+      user.profile_pic = DEFAULT_PROFILE_PIC;
     }
 
     res.json(user);

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -65,7 +65,12 @@ const hourPatterns = {
   },
 };
 
+// default profile picture url for users who don't have one
+const DEFAULT_PROFILE_PIC =
+  "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png";
+
 module.exports = {
   daysOfWeek,
   hourPatterns,
+  DEFAULT_PROFILE_PIC,
 };

--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -57,7 +57,55 @@
   width: 40%;
   /* center of the edit form */
   margin: 0 auto;
+  display: block;
+  margin-bottom: 15px;
+  object-fit: cover;
+  aspect-ratio: 1/1;
+  border: 3px solid #CED7E4;
+}
 
+/* profile picture container and actions */
+.profile-pic-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.profile-pic-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 10px;
+  width: 100%;
+  max-width: 250px;
+}
+
+.change-pic-button, .remove-pic-button {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.change-pic-button {
+  background-color: #CED7E4;
+  color: #333;
+}
+
+.change-pic-button:hover {
+  background-color: #b8c4d6;
+}
+
+.remove-pic-button {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.remove-pic-button:hover {
+  background-color: #f5c6cb;
 }
 
 /* edit button */


### PR DESCRIPTION
## Description

This PR adds profile picture editing to the Dashboard and improves default image handling across the app. On the backend, a DEFAULT_PROFILE_PIC constant was added and checks were implemented in both the /me and /users/:userId routes to assign the default image if none exists. This ensures all users, including older accounts, have a visible profile picture for a consistent experience.

On the frontend, users can now upload, change, or remove their profile picture. A hidden file input is managed using useRef, triggered by a custom "Change" button. Selected images are validated, resized, and converted to base64 before being submitted. The UI includes a live preview, a "Remove" button to revert to the default image, and styling updates to match the app's design.

Next steps: Continue polishing the UI and ensure consistency across all devices.

## Milestones
Polish and stretch features

## Resources
https://medium.com/web-dev-survey-from-kyoto/how-to-customize-the-file-upload-button-in-react-b3866a5973d8

## Demo
https://pxl.cl/7P4x3

